### PR TITLE
Fix rematch resetting bug

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -65,7 +65,7 @@ const app = Vue.createApp({
     rematch() {
       this.startMessage = "じゃ～ん　け～ん～";
       this.startCPUCycle();
-      this.isFinish = "";
+      this.isFinish = false;
       this.result = "";
     },
   },


### PR DESCRIPTION
## Summary
- ensure `rematch` sets `isFinish` to boolean `false`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb2a8a81083208d72cece362adcd5