### PR TITLE
Implement win/loss counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     </div>
     <div class="result" v-if="result">{{result}}</div>
     <button class="rematch-button" v-if="isFinish" @click="rematch">もう一回！</button>
+    <div class="score">勝：{{ winCount }}　負：{{ loseCount }}</div>
   </div>
   <script src="https://unpkg.com/vue@3"></script>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -49,6 +49,12 @@ body {
   font-weight: bold;
 }
 
+.score {
+  margin-top: 10px;
+  font-size: 20px;
+  font-weight: bold;
+}
+
 .rematch-button {
   width: 200px;
   margin-top: 20px;
@@ -89,5 +95,9 @@ body {
     width: 100%;
     padding: 5px 20px;
     border-radius: 30px;
+  }
+
+  .score {
+    font-size: 16px;
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,8 @@ const app = Vue.createApp({
       currentCPUImage: "src/assets/img/rock.png",
       result: "",
       isFinish: false,
+      winCount: 0,
+      loseCount: 0,
       startMessage: "じゃ～ん　け～ん～",
     };
   },
@@ -50,12 +52,14 @@ const app = Vue.createApp({
           (userHand === "paper" && cpuHand === "rock")
         ) {
           this.result = "あなたの勝ち！";
+          this.winCount += 1;
           this.showConfetti();
           setTimeout(() => {
             this.isFinish = true;
           }, 700);
         } else {
           this.result = "あなたの負け";
+          this.loseCount += 1;
           setTimeout(() => {
             this.isFinish = true;
           }, 500);


### PR DESCRIPTION
## Summary
- track wins and losses in app state
- increment the counters after each round
- show counters under the rematch button
- style the score display

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbfebac6c8320a166b1301e3b2f11