### PR TITLE
Prevent rematch without clicking 'もう一回'

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
       <img :src="currentCPUImage" :alt="cpuHand">
     </div>
     <div class="hand-buttons">
-      <button @click="playJanken('rock')">
+      <button @click="playJanken('rock')" :disabled="isFinish">
         <img src="src/assets/img/rock.png" alt="グー" class="user-handImg">
         <p class="">グー</p>
       </button>
-      <button @click="playJanken('scissors')">
+      <button @click="playJanken('scissors')" :disabled="isFinish">
         <img src="src/assets/img/scissors.png" alt="チョキ" class="user-handImg">
         <p>チョキ</p>
       </button>
-      <button @click="playJanken('paper')">
+      <button @click="playJanken('paper')" :disabled="isFinish">
         <img src="src/assets/img/paper.png" alt="パー" class="user-handImg">
         <p>パー</p>
       </button>

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -43,6 +43,12 @@ body {
   background-color: #cacfd2;
 }
 
+.hand-buttons button:disabled {
+  background-color: #eee;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 .result {
   margin-top: 20px;
   font-size: 40px;

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,8 @@ const app = Vue.createApp({
       });
     },
     playJanken(userHand) {
+      if (this.isFinish) return;
+
       this.stopCPUCycle();
 
       const randomIndex = Math.floor(Math.random() * this.hands.length);


### PR DESCRIPTION
## Summary
- disable janken buttons when the round is finished
- guard `playJanken` if the previous result hasn't been reset
- add basic styles for disabled state

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840efc435d48320ad2a8dab9c145dbf